### PR TITLE
fix(linalg3): linkage conflict for `fabs()`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: [3.11]
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/zoltan-tests.yml
+++ b/.github/workflows/zoltan-tests.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           conda info
           conda install -c conda-forge numpy cython
-          python -m pip install mpi4py cyarray
+          python -m pip install mpi4py
+          python -m pip install https://github.com/pypr/cyarray/zipball/master
           python -m pip install --no-build-isolation https://github.com/pypr/pyzoltan/zipball/master
           python -m pip install https://github.com/pypr/compyle/zipball/master
           python -m pip install -r requirements.txt

--- a/.github/workflows/zoltan-tests.yml
+++ b/.github/workflows/zoltan-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.11]
 
     env:
       USE_TRILINOS: 1


### PR DESCRIPTION
Seems like extern fabs() in linalg3.pyx is assumed to have c++ linkage as linalg3.cpp file is generated. However, this fabs() ends up conflicting with the declaration with c linkage from /usr/include/x86_64-linux-gnu/bits/mathcalls.h on ubuntu github actions runner.